### PR TITLE
Add Daily Reminder To Log Mood

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,13 @@
         <textarea id="note" placeholder="Write a note..."></textarea>
         <button id="saveMoodBtn">Save Mood</button>
 
+        <div class="reminder">
+            <label for="reminderTime">Set Daily Reminder Time:</label>
+            <input type="time" id="reminderTime">
+            <button id="setReminderBtn">Set Reminder</button>
+
+        </div>
+
         <div class="history">
             <h3>Your Mood History:</h3>
             <ul id="historyList"></ul>

--- a/script.js
+++ b/script.js
@@ -91,6 +91,15 @@ setReminderBtn.addEventListener('click', () => {
     const time = reminderInput.value;
     if (time) {
         localStorage.setItem('reminderTime', time);
+
+        if (Notification.permission !== 'granted') {
+            Notification.requestPermission().then(permission => {
+                if (permission === 'denied') {
+                    alert('You have blocked notifications. Please enable them in your browser settings to receive mood reminders.');
+                }
+            });
+        }
+
         alert('Reminder time saved!');
     }
 });

--- a/script.js
+++ b/script.js
@@ -4,6 +4,11 @@ const saveMoodBtn = document.getElementById('saveMoodBtn');
 const historyList = document.querySelector('.history ul');
 const moodHistory = JSON.parse(localStorage.getItem('moodHistory')) || [];
 
+// Permission for notification on loading page
+if ('Notification' in window && Notification.permission !== 'granted') {
+    Notification.requestPermission();
+}
+
 // Get current date and time
 function getCurrentDateTime() {
     const now = new Date();
@@ -77,3 +82,15 @@ saveMoodBtn.addEventListener('click', saveMood);
 
 // Initialize the app
 updateHistory();
+
+// Set reminder time
+const setReminderBtn = document.getElementById('setReminderBtn');
+const reminderInput = document.getElementById('reminderTime');
+
+setReminderBtn.addEventListener('click', () => {
+    const time = reminderInput.value;
+    if (time) {
+        localStorage.setItem('reminderTime', time);
+        alert('Reminder time saved!');
+    }
+});

--- a/script.js
+++ b/script.js
@@ -94,3 +94,21 @@ setReminderBtn.addEventListener('click', () => {
         alert('Reminder time saved!');
     }
 });
+
+// Check for reminder every 60 seconds
+let lastNotificationTime = null;
+
+setInterval(() => {
+    const reminderTime = localStorage.getItem('reminderTime');
+    if (!reminderTime || Notification.permission !== 'granted') return;
+
+    const now = new Date();
+    const currentTime = now.toTimeString().slice(0, 5); 
+
+    if (currentTime === reminderTime && currentTime !== lastNotificationTime) {
+        new Notification('Mood Tracker', {
+            body: "It's time to log your mood",
+        });
+        lastNotificationTime = currentTime;
+    }
+}, 60000);

--- a/style.css
+++ b/style.css
@@ -144,3 +144,15 @@ h1 {
         opacity: 1;
     }
 }
+
+.reminder {
+    margin-top: 10px;
+}
+#setReminderBtn {
+    background-color:#28a745;
+    color: white;
+    border-radius: 5px;
+    border: none;
+    padding: 5px 10px;
+    cursor: pointer;
+}


### PR DESCRIPTION
Created a new feature that allows users to set a daily reminder time to log their mood using the browser Notification API.
Features Implemented:
-New input and button to set reminder time
-Reminder time is saved to localStorage
-Every minute, it checks if it's the set time and triggers a desktop notification
-Added check for Notification.permission and user instructions if notifications are blocked

Screenshots:  
<img width="1037" height="937" alt="Screenshot (39)" src="https://github.com/user-attachments/assets/4bf4c636-96a9-46f3-86de-15794e6fdd77" />

<img width="1531" height="969" alt="Screenshot (40)" src="https://github.com/user-attachments/assets/fbf0aa4d-e9ea-4539-a0a1-10e5b8c341aa" />

Please let me know if there are any changes that can be made.
Thanks,
Artemis231005
Gssoc Contributer

